### PR TITLE
init -> setup, setup arguments tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,7 @@ Lazy:
 ```lua
 return {
   "paulpatault/compit",
-  config = function()
-    require('compit').init(
-      { specials = { ext1 = "specific command", ... }
-      }) end,
+  opts = { specials = { ext1 = "specific command", ... } },
   dependencies = "skywind3000/asyncrun.vim"
 }
 ```


### PR DESCRIPTION
- Rename `init` in `setup` to use opts argument in [lazy plugin configuration](https://www.lazyvim.org/configuration/plugins)
- Test if `options <> nil` in `setup()` because if you run `setup()`, the function may crash.

:sunglasses: 