### PR TITLE
check options.specials ~= nil in setup

### DIFF
--- a/lua/compit/init.lua
+++ b/lua/compit/init.lua
@@ -106,7 +106,9 @@ local function setup(options)
     if options.qf_height ~= nil then
       qf_height = options.qf_height
     end
-    user_table = options.specials
+    if options.specials ~= nil then
+      user_table = options.specials
+    end
   end
   local ok, err, code = os.rename(path, path)
   if not ok and code ~= 13 then


### PR DESCRIPTION
if `options.specials` is nil, `user_table` gets nil
and in function `get_command` line 26 : `pairs(user_table)` crash is `user_table` is nil :(